### PR TITLE
review img-to-doc-csv.yml & img-to-doc-csv.py (last line)

### DIFF
--- a/.github/workflows/img-to-doc-csv.yml
+++ b/.github/workflows/img-to-doc-csv.yml
@@ -1,4 +1,5 @@
 name: img-to-doc-csv
+
 on:
     workflow_dispatch:
 
@@ -10,7 +11,7 @@ jobs:
               uses: actions/checkout@v4
             - name: transform csv
               run: python scripts/img-to-doc-csv/img-to-doc-csv.py
-            - name: commit data
+            - name: commit transformed csv
               uses: stefanzweifel/git-auto-commit-action@v5
               with:
                 commit_message: transformed csv


### PR DESCRIPTION
there is an error related to the output file path indicated in the img-to-doc-csv.py https://github.com/auden-in-austria-digital/aad-data/blob/cd2156d7bc93bda6a1826ddc8bf63e8382871b97/scripts/img-to-doc-csv/img-to-doc-csv.py#L45
```
 Traceback (most recent call last):
  File "/home/runner/work/aad-data/aad-data/scripts/img-to-doc-csv/img-to-doc-csv.py", line 45, in <module>
    transform_csv('https://raw.githubusercontent.com/auden-in-austria-digital/aad-data/main/doc-data/csv/img_doc_id.csv', 'doc_id', 'img_id', '../../doc-data/csv/doc_img_id')
  File "/home/runner/work/aad-data/aad-data/scripts/img-to-doc-csv/img-to-doc-csv.py", line 33, in transform_csv
    with open(output_file, 'w', newline='', encoding='utf-8') as newfile:  # open/create output CSV file in write mode
FileNotFoundError: [Errno 2] No such file or directory: '../../doc-data/csv/doc_img_id.csv'
Error: Process completed with exit code 1.
```
the path does work when run locally, but not when run in the GitHub Actions environment